### PR TITLE
Fix REST search endpoint empty response and reset post data

### DIFF
--- a/core/classes/class-rest-controller.php
+++ b/core/classes/class-rest-controller.php
@@ -69,8 +69,9 @@ class Rest_Controller extends \WP_REST_Controller {
 
 		$the_query = wppedia_get_posts( $query_args );
 
-		if ( ! $the_query->have_posts() )
-			return null;
+		if ( ! $the_query->have_posts() ) {
+			return [];
+		}
 
 		$searchables = [];
 		while ( $the_query->have_posts() ) {
@@ -87,6 +88,8 @@ class Rest_Controller extends \WP_REST_Controller {
 			];
 
 		}
+
+		wp_reset_postdata();
 
 		return $searchables;
 


### PR DESCRIPTION
### Motivation
- Ensure the REST search endpoint always returns a list-shaped payload so frontend indexing (e.g. Fuse.js) does not fail when no glossary posts exist.
- Prevent leaking global post state after running a custom loop by restoring post data for later code paths.
- Basic repository inspection was used to locate the REST controller and validate the change.

### Description
- Changed `Rest_Controller::get_wiki_entry_searchables()` to return an empty array (`[]`) when no posts are found instead of `null` to keep the response shape consistent (file: `core/classes/class-rest-controller.php`).
- Added a call to `wp_reset_postdata()` after the custom loop to restore global post state (file: `core/classes/class-rest-controller.php`).
- Kept behavior and payload contents for found posts unchanged while improving safety for empty and subsequent requests.

### Testing
- Ran `php -l core/classes/class-rest-controller.php` and it returned no syntax errors.
- Attempted `composer install` but it failed due to network/GitHub fetch errors in the environment, so `vendor/bin/phpunit` could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d8f812dc483269f6a1372de3c9c82)