### PR TITLE
docs: restructure into hierarchical developer and user documentation

### DIFF
--- a/docs/developers/architecture/overview.md
+++ b/docs/developers/architecture/overview.md
@@ -1,0 +1,54 @@
+# Architecture Overview
+
+This page explains the core pieces of WPPedia so extension work can be scoped correctly.
+
+## 1) Runtime bootstrap
+
+- The plugin entry point is `wppedia.php`.
+- The `WPPedia` class initializes shared services in its internal container.
+- During initialization, the plugin registers:
+  - template handling,
+  - REST controller,
+  - WP query setup,
+  - admin interfaces,
+  - options/settings,
+  - post meta,
+  - post type registration,
+  - cross-link and tooltip modules,
+  - DB upgrade routines.
+
+### Why this matters for extension authors
+
+When extending behavior, choose the integration layer based on timing:
+
+- **Theme/frontend output change** → template overrides/hooks.
+- **Data/query behavior** → query setup/helpers/hooks.
+- **Admin settings behavior** → options/admin hooks.
+- **Cross-link/tooltip behavior** → module-level hooks/filters.
+
+## 2) Folder-level map
+
+- `core/classes/` – object-oriented systems (admin/options/template modules, etc.).
+- `core/inc/` – functional helpers and glue code.
+- `template-hooks/` – hook callbacks connected to template action points.
+- `templates/` – default rendered templates that can be overridden.
+- `source/` and `dist/` – source assets and compiled bundles.
+- `tests/` – PHPUnit tests.
+
+## 3) Rendering flow (high level)
+
+1. Request resolves to WPPedia archive/single/search context.
+2. Template loading logic determines plugin template vs theme override.
+3. Template files fire action hooks (`do_action`) for sections.
+4. `template-hooks/*.php` callbacks render concrete blocks.
+5. Additional modules (search, navigation, cross-link, tooltip) alter output where applicable.
+
+## 4) Stable extension points
+
+Most stable extension points in this project are:
+
+- action/filter hooks with `wppedia_` prefix,
+- template overrides in your theme,
+- selected shortcodes and helper functions.
+
+Prefer these over editing plugin core files directly.

--- a/docs/developers/contributing/readme.md
+++ b/docs/developers/contributing/readme.md
@@ -1,0 +1,64 @@
+# Contribution Guide (WPPedia Core and Extensions)
+
+This page explains how to contribute safely and predictably.
+
+## 1) Local environment
+
+Install dependencies:
+
+```bash
+composer install
+npm install
+```
+
+Build assets:
+
+```bash
+npm run build
+```
+
+Use watch mode during active frontend work:
+
+```bash
+npm run dev
+```
+
+## 2) Branching and scope
+
+- Create focused branches (one concern per branch).
+- Keep PRs small enough for detailed review.
+- Separate refactoring from behavior changes where possible.
+
+## 3) Coding expectations
+
+- Follow project naming/style conventions.
+- Prefer extension points over hard-coded behavior.
+- Preserve backward compatibility of hooks/options where possible.
+- Add inline docs for new hooks and non-obvious logic.
+
+## 4) Documentation expectations
+
+When behavior changes are user-visible or extension-relevant:
+
+- update user docs under `docs/users/`,
+- update developer docs under `docs/developers/`,
+- update root docs index if navigation changes.
+
+## 5) Validation before PR
+
+Minimum:
+
+1. Run test suite (`vendor/bin/phpunit`).
+2. Rebuild assets if `source/` changed.
+3. Manually validate primary glossary flows.
+4. Confirm docs are updated.
+
+## 6) PR writing tips
+
+A strong PR should include:
+
+- problem statement,
+- implementation summary,
+- extension/backward-compatibility notes,
+- test evidence,
+- follow-up items (if any).

--- a/docs/developers/extending/hooks.md
+++ b/docs/developers/extending/hooks.md
@@ -1,0 +1,94 @@
+# Hook Reference and Extension Patterns
+
+This page focuses on practical hooks for extending WPPedia behavior.
+
+## 1) Template path and resolution hooks
+
+### `wppedia_template_path` (filter)
+
+Use this to change the theme subfolder WPPedia reads templates from.
+
+```php
+add_filter('wppedia_template_path', function ($path) {
+    return 'my-custom-glossary';
+});
+```
+
+### `wppedia_locate_template` (filter)
+
+Lets you rewrite the final template path before it is loaded.
+
+### `wppedia_get_template_part` (filter)
+
+Lets you intercept template part loading and point to a template shipped by your own plugin.
+
+## 2) Layout and loop action hooks
+
+Common action points used by archive/single templates:
+
+- `wppedia_before_main_content`
+- `wppedia_after_main_content`
+- `wppedia_sidebar`
+- `wppedia_before_post_loop`
+- `wppedia_after_post_loop`
+- `wppedia_before_loop_item`
+- `wppedia_before_loop_item_title`
+- `wppedia_loop_item_title`
+- `wppedia_after_loop_item_title`
+- `wppedia_after_loop_item`
+- `wppedia_before_single_post`
+- `wppedia_single_post`
+- `wppedia_after_single_post`
+- `wppedia_archive_description`
+- `wppedia_no_entries_found`
+
+### Example: prepend a custom archive intro block
+
+```php
+add_action('wppedia_before_post_loop', function () {
+    echo '<div class="my-glossary-intro">Browse our glossary by topic.</div>';
+}, 5);
+```
+
+### Example: add a custom CTA below excerpts
+
+```php
+add_action('wppedia_after_loop_item_title', function () {
+    echo '<a class="my-cta" href="/contact">Need help with this term?</a>';
+}, 30);
+```
+
+## 3) Title, excerpt, and form filters
+
+Useful output filters:
+
+- `wppedia_page_title`
+- `wppedia_tooltip_excerpt`
+- `wppedia_show_page_title`
+- `wppedia_search_input_id`
+- `wppedia_searchform_attrs__role`
+- `wppedia_searchform_attrs__method`
+- `wppedia_searchform_attrs__class`
+- `wppedia_searchform_attrs__id`
+
+### Example: customize glossary page title
+
+```php
+add_filter('wppedia_page_title', function ($title) {
+    if (is_post_type_archive('glossary')) {
+        return 'Knowledge Base';
+    }
+    return $title;
+});
+```
+
+## 4) Admin-side integration hook
+
+- `wppedia_admin_settings_page_header_content` can be used to output custom information above settings sections.
+
+## 5) Hooking strategy recommendations
+
+- Use explicit priorities and comment why (`10`, `20`, etc.).
+- Prefer one callback per concern.
+- Avoid anonymous functions in large projects where unhooking is required.
+- Add compatibility checks (`function_exists`, `class_exists`) for safer deployments.

--- a/docs/developers/extending/overview.md
+++ b/docs/developers/extending/overview.md
@@ -1,0 +1,52 @@
+# Extending WPPedia: Overview
+
+WPPedia was designed to be extended via WordPress conventions. In most cases, you should create a small companion plugin or theme integration layer instead of modifying WPPedia core directly.
+
+## 1) Recommended extension methods
+
+### Method A: Hook-based customization (preferred)
+
+Use `add_action` and `add_filter` against WPPedia hook names to:
+
+- inject output before/after built-in blocks,
+- alter computed labels/titles,
+- adjust template paths and template file selection,
+- tune search form attributes and other view-level data.
+
+This method survives plugin updates best.
+
+### Method B: Theme template overrides
+
+Copy a template file from `templates/` into your theme under the WPPedia template path, then modify the copy.
+
+Good for:
+
+- major markup refactors,
+- framework-specific wrappers,
+- custom HTML structure.
+
+### Method C: Companion plugin module
+
+Create your own plugin that:
+
+- loads after WPPedia,
+- registers hooks on `init` / `wp` / template actions,
+- encapsulates business logic for reusable deployments.
+
+This method is ideal for agencies or productized implementations.
+
+## 2) Decision matrix
+
+- Need to **insert or reorder content**? → Start with hooks.
+- Need to **change full markup**? → Use template overrides.
+- Need **multi-site reuse/versioning**? → Companion plugin.
+
+In real projects, these methods are often combined.
+
+## 3) Safe extension checklist
+
+- Never edit WPPedia plugin files directly in production.
+- Prefix your own hooks/functions/classes.
+- Document every WPPedia hook you rely on.
+- Keep custom code in git.
+- Re-test after each WPPedia update.

--- a/docs/developers/extending/shortcodes-and-frontend.md
+++ b/docs/developers/extending/shortcodes-and-frontend.md
@@ -1,0 +1,42 @@
+# Shortcodes and Frontend Integration
+
+This page explains practical frontend integration patterns beyond template overrides.
+
+## 1) Understand the boundary: content vs shell
+
+- **Content shell** (archive page, wrapper, list/single layout) is primarily template-driven.
+- **In-content behavior** (cross-linking, tooltip text, excerpts, search form attributes) is often hook/filter-driven.
+
+Use the right tool for the right layer.
+
+## 2) Search form integration
+
+WPPedia search form output can be customized by:
+
+- template override of `templates/search/form.php`,
+- search form attribute filters,
+- before/after search form actions.
+
+Useful when integrating utility CSS frameworks or custom JS search behavior.
+
+## 3) Navigation integration
+
+The initial-character navigation can be:
+
+- enabled/disabled by settings,
+- repositioned via template hooks,
+- overridden via template customization.
+
+## 4) Companion plugin pattern (recommended)
+
+For reusable frontend behavior, create a custom plugin, e.g.:
+
+- `my-company-wppedia-extension.php`
+- `src/Rendering/GlossaryLayout.php`
+- `src/Enhancements/TooltipTweaks.php`
+
+Benefits:
+
+- independent versioning,
+- clearer ownership,
+- easier reuse across sites.

--- a/docs/developers/readme.md
+++ b/docs/developers/readme.md
@@ -1,3 +1,31 @@
-# WPPedia Developer Docs
+# WPPedia Developer Documentation
 
-## Shortcodes
+This section is intended for plugin/theme developers and agency teams that want to extend WPPedia rather than only configure it.
+
+## Start here
+
+1. [Architecture overview](./architecture/overview.md) – where the main systems live and how requests are rendered.
+2. [Extending WPPedia](./extending/overview.md) – practical extension approaches and decision guidance.
+3. [Templating](./templating/overview.md) – the most important section if you want to customize output.
+
+## Detailed guides
+
+### Extending
+- [Extension overview](./extending/overview.md)
+- [Hook reference and examples](./extending/hooks.md)
+- [Shortcodes and frontend integration](./extending/shortcodes-and-frontend.md)
+
+### Templating
+- [Templating overview](./templating/overview.md)
+- [Template override guide](./templating/overrides.md)
+- [Template hooks guide](./templating/hooks.md)
+
+### Quality and contribution
+- [Testing guide](./testing/readme.md)
+- [Contribution workflow](./contributing/readme.md)
+
+## Who should read which page?
+
+- **Theme developer**: start with templating docs.
+- **Plugin developer**: start with extending + hooks docs.
+- **Core contributor**: start with architecture, then testing and contribution docs.

--- a/docs/developers/templating/hooks.md
+++ b/docs/developers/templating/hooks.md
@@ -1,0 +1,52 @@
+# Template Hooks Deep Dive
+
+This page explains how WPPedia’s template hooks are wired and how to safely extend them.
+
+## 1) Hook registration model
+
+WPPedia maps template sections to callback functions in `template-hooks/hooks.php`.
+
+Examples:
+
+- `wppedia_before_main_content` → wrapper start/navigation/search injection.
+- `wppedia_single_post` → featured image/title/content/page links.
+- `wppedia_before_loop_item_title` / `wppedia_after_loop_item_title` → loop card internals.
+
+Because these are standard WordPress actions, you can:
+
+- add additional callbacks,
+- remove default callbacks,
+- replace output order via priorities.
+
+## 2) Reordering default content blocks
+
+Example: move pagination earlier in the page:
+
+```php
+remove_action('wppedia_after_main_content', 'wppedia_posts_pagination', 10);
+add_action('wppedia_before_post_loop', 'wppedia_posts_pagination', 50);
+```
+
+Use this pattern carefully and keep it in a dedicated integration file.
+
+## 3) Inserting custom content around single entries
+
+```php
+add_action('wppedia_before_single_post', function () {
+    echo '<div class="glossary-single-notice">Reviewed by editorial team</div>';
+}, 5);
+```
+
+## 4) Guarding your hooks
+
+For compatibility:
+
+- register hooks only when WPPedia is active,
+- use `function_exists('WPPedia')` checks when needed,
+- isolate callbacks in namespaced classes for large projects.
+
+## 5) Debugging hook behavior
+
+- Confirm callback priority order.
+- Temporarily log active callbacks with `has_action` checks.
+- Verify template actually fires the action (`do_action`).

--- a/docs/developers/templating/overrides.md
+++ b/docs/developers/templating/overrides.md
@@ -1,0 +1,53 @@
+# Template Overrides: Step-by-Step
+
+## 1) Default override location
+
+By default, copy template files into:
+
+```text
+your-theme/wppedia/
+```
+
+Examples:
+
+- `templates/archive.php` → `your-theme/wppedia/archive.php`
+- `templates/content-single.php` → `your-theme/wppedia/content-single.php`
+- `templates/search/form.php` → `your-theme/wppedia/search/form.php`
+
+## 2) Overriding a loop item layout
+
+If you want a custom card design for glossary list entries:
+
+1. Copy `templates/content-archive.php` to your theme override path.
+2. Keep existing action hooks in place where possible.
+3. Wrap sections with your own CSS classes.
+4. Add any additional block after `wppedia_after_loop_item_title` via hook.
+
+This gives you custom markup while preserving future extension compatibility.
+
+## 3) Changing template path globally
+
+If your team uses a different structure, change the template path with:
+
+```php
+add_filter('wppedia_template_path', function () {
+    return 'integrations/wppedia';
+});
+```
+
+Then WPPedia will load from `your-theme/integrations/wppedia/...`.
+
+## 4) Override maintenance workflow
+
+For each WPPedia update:
+
+1. Review changed files under plugin `templates/`.
+2. Compare with your overridden files.
+3. Merge relevant fixes while preserving your customizations.
+4. Smoke-test archive/single/search/tooltip UX.
+
+## 5) Common pitfalls
+
+- Removing core action hooks unintentionally.
+- Copying too many templates upfront (harder maintenance).
+- Ignoring child theme precedence when testing.

--- a/docs/developers/templating/overview.md
+++ b/docs/developers/templating/overview.md
@@ -1,0 +1,42 @@
+# Templating in WPPedia (Key Extension Surface)
+
+Templating is one of the most powerful extension points in WPPedia and is usually the first place to customize output for real projects.
+
+## 1) How template resolution works
+
+WPPedia template loading follows a WordPress-style fallback model:
+
+1. Look in your (child) theme under the configured WPPedia template path.
+2. If not found, use plugin defaults from `templates/`.
+3. Allow final path rewrites via template filters.
+
+By default, the theme path is `yourtheme/wppedia/...`, and this can be changed through `wppedia_template_path`.
+
+## 2) The two mechanisms you should combine
+
+### Template overrides
+
+Use when changing HTML structure or introducing design-system wrappers.
+
+### Template action hooks
+
+Use when inserting/reordering sections without copying entire templates.
+
+In many cases, hooks should be tried first because they reduce upgrade maintenance.
+
+## 3) Core template groups
+
+- `templates/archive.php` – archive rendering and loop orchestration.
+- `templates/content-single.php` – single glossary entry rendering.
+- `templates/content-archive.php` – loop item rendering.
+- `templates/global/*` – wrappers/sidebar pieces.
+- `templates/loop/*` – loop subparts (title, image, excerpt, wrappers).
+- `templates/search/form.php` – glossary search form.
+- `templates/nav/char-navigation.php` – initial-character navigation.
+
+## 4) Upgrade-safe templating principles
+
+- Keep custom overrides minimal and purpose-specific.
+- Track overridden files in a dedicated changelog.
+- On WPPedia updates, diff your overrides against new plugin templates.
+- Prefer hook-based insertions over full file copies where possible.

--- a/docs/developers/testing/readme.md
+++ b/docs/developers/testing/readme.md
@@ -1,0 +1,46 @@
+# Testing Guide
+
+This page covers practical testing for WPPedia extensions and contributions.
+
+## 1) Automated tests
+
+Run the plugin’s PHPUnit suite:
+
+```bash
+vendor/bin/phpunit
+```
+
+Current baseline tests are in `tests/` and cover utility and glossary-related behavior.
+
+## 2) Manual functional testing checklist
+
+When changing extension points, always validate:
+
+- Glossary archive renders correctly.
+- Single glossary entry renders correctly.
+- Search form behavior and search results.
+- Initial-letter navigation behavior.
+- Tooltip and cross-link behaviors (if enabled).
+
+## 3) Template customization regression checklist
+
+If you changed template hooks/overrides:
+
+- Verify wrapper open/close structure is balanced.
+- Verify default callbacks still execute (unless intentionally removed).
+- Verify no duplicate blocks were introduced by mixed hooks and overrides.
+- Verify mobile rendering and keyboard navigation.
+
+## 4) Suggested test matrix for extension plugins
+
+- **Theme matrix**: default theme + target production theme.
+- **Config matrix**: with/without navigation, with/without search bar, with/without tooltips.
+- **Content matrix**: short entries, long entries, special characters, umlauts/accented characters.
+
+## 5) CI recommendations
+
+For teams shipping WPPedia extensions:
+
+- run PHPUnit on every PR,
+- add static analysis/linting for your extension code,
+- include at least one smoke test against a real WP environment before release.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,11 +1,10 @@
 # WPPedia Documentation
 
-## Getting started
-Transform your WordPress website into a thoroughbred encyclopedia.  
-[Learn how](./getting-started.md)
+## Main documentation sections
 
-## Codex
+- [Developer documentation](./developers/readme.md)
+- [User documentation](./users/readme.md)
 
-## Theming
+## Legacy pages
 
-## Action & Filter Reference
+- [Legacy getting started page](./getting-started.md)

--- a/docs/users/content/create-glossary-entries.md
+++ b/docs/users/content/create-glossary-entries.md
@@ -1,0 +1,42 @@
+# Create Glossary Entries
+
+## 1) Add a new entry
+
+1. Go to **Glossary → Add New**.
+2. Enter the glossary term in the title field.
+3. Add the explanation in the content editor.
+4. Add media/links/examples where useful.
+5. Publish.
+
+> Screenshot placeholder: “Add New Glossary Entry” editor with title + content.
+
+## 2) Writing guidelines for strong entries
+
+A useful glossary entry usually contains:
+
+- concise first-sentence definition,
+- context on why the term matters,
+- example usage,
+- links to related terms.
+
+Recommended structure:
+
+1. Definition
+2. Context/when to use
+3. Example
+4. Related terms
+
+## 3) Updating existing entries
+
+- Keep permalink stability in mind when renaming terms.
+- Update outdated examples regularly.
+- If major wording changes are made, document editorial rationale.
+
+## 4) Publishing checklist
+
+Before publishing:
+
+- spelling and grammar reviewed,
+- links tested,
+- title format matches style guide,
+- entry is placed in correct editorial context.

--- a/docs/users/content/editorial-best-practices.md
+++ b/docs/users/content/editorial-best-practices.md
@@ -1,0 +1,35 @@
+# Editorial Workflow and Quality Best Practices
+
+## 1) One concept per entry
+
+Avoid combining multiple concepts into one glossary post. Smaller, focused entries improve search relevance and cross-link quality.
+
+## 2) Consistent naming and tone
+
+Define an editorial style for:
+
+- capitalization,
+- abbreviations,
+- formal/informal tone,
+- internal linking format.
+
+## 3) Keep glossary content evergreen
+
+Set a recurring review cadence (monthly/quarterly):
+
+- update outdated terms,
+- remove duplicates,
+- merge overlapping entries,
+- improve weak definitions.
+
+## 4) Internal linking strategy
+
+Link related entries to create a knowledge graph for users. This improves discoverability and session depth.
+
+## 5) Governance suggestion
+
+Use a lightweight workflow:
+
+- **Author** drafts entry,
+- **Reviewer** validates technical correctness,
+- **Editor/Owner** approves publication.

--- a/docs/users/frontend/archive-and-single-pages.md
+++ b/docs/users/frontend/archive-and-single-pages.md
@@ -1,0 +1,36 @@
+# Glossary Archive and Single Pages
+
+## 1) Archive page behavior
+
+The glossary archive is the main browse page where users can:
+
+- discover terms,
+- scan excerpts,
+- use search and/or character navigation.
+
+What to validate:
+
+- title/header clarity,
+- readable excerpts,
+- consistent card/list spacing,
+- pagination behavior.
+
+## 2) Single page behavior
+
+Each term page should make definition lookup easy and fast.
+
+What to validate:
+
+- term title prominence,
+- content readability,
+- optional featured image usage,
+- related navigation utilities.
+
+## 3) UX recommendations
+
+- Keep archive cards concise.
+- Put full detail on single pages.
+- Ensure links between related terms are visible.
+
+> Screenshot placeholder: Glossary archive page.
+> Screenshot placeholder: Single glossary entry page.

--- a/docs/users/frontend/tooltips-and-crosslinking.md
+++ b/docs/users/frontend/tooltips-and-crosslinking.md
@@ -1,0 +1,25 @@
+# Tooltips and Cross-Linking
+
+## 1) What this feature does
+
+Tooltip/cross-link functionality helps users understand terms inline without losing reading context.
+
+Depending on configuration, matching glossary terms in content may:
+
+- become links to glossary entries,
+- show tooltip definitions on hover/focus.
+
+## 2) Good usage patterns
+
+- Keep definitions concise for tooltip readability.
+- Avoid over-linking every repeated term occurrence.
+- Test accessibility and mobile behavior.
+
+## 3) QA checklist
+
+- Verify terms are linked where expected.
+- Verify no false-positive linking in unrelated words.
+- Verify tooltip content is readable and not truncated unexpectedly.
+- Verify behavior with cache/CDN enabled.
+
+> Screenshot placeholder: Inline tooltip shown over linked glossary term.

--- a/docs/users/getting-started/initial-setup-checklist.md
+++ b/docs/users/getting-started/initial-setup-checklist.md
@@ -1,0 +1,31 @@
+# Initial Setup Checklist
+
+Use this checklist right after activation.
+
+## 1) Configure core settings
+
+- Review glossary slug/permalink settings.
+- Decide if search bar should appear on archive and single pages.
+- Decide if initial-letter navigation should be visible.
+- Review tooltip/cross-link defaults.
+
+> Screenshot placeholder: WPPedia settings page, highlighting key first-time options.
+
+## 2) Create sample content
+
+- Add 3–5 glossary terms with realistic content.
+- Include at least one long entry and one short entry.
+- Add a term with special characters for permalink validation.
+
+## 3) Validate frontend
+
+- Visit glossary archive.
+- Open at least two single entries.
+- Test search from glossary UI.
+- Check responsiveness on mobile.
+
+## 4) Finalize editorial process
+
+- Define naming standard for terms.
+- Define review/publishing workflow.
+- Assign responsibilities (author, reviewer, publisher).

--- a/docs/users/getting-started/install-and-activate.md
+++ b/docs/users/getting-started/install-and-activate.md
@@ -1,0 +1,37 @@
+# Install and Activate WPPedia
+
+## 1) Install from WordPress admin (recommended)
+
+1. Go to **Plugins → Add New** in your WordPress admin.
+2. Search for **WPPedia**.
+3. Click **Install Now**.
+4. Click **Activate**.
+
+After activation, confirm that a **Glossary** menu item appears in the admin sidebar.
+
+> Screenshot placeholder: Plugins screen after activation.
+> Screenshot placeholder: Admin sidebar showing “Glossary”.
+
+## 2) Install by uploading ZIP
+
+1. Download the plugin ZIP package.
+2. Go to **Plugins → Add New → Upload Plugin**.
+3. Upload the ZIP and click **Install Now**.
+4. Click **Activate Plugin**.
+
+## 3) Validate installation
+
+Quick validation checklist:
+
+- Plugin is listed as **Active**.
+- Glossary menu is visible.
+- You can open glossary settings.
+- No immediate PHP/admin errors appear.
+
+## 4) Update behavior
+
+WPPedia updates follow standard WordPress plugin update flow:
+
+- update notification appears in Plugins list,
+- one-click update from admin,
+- recommended to backup before updating on production sites.

--- a/docs/users/readme.md
+++ b/docs/users/readme.md
@@ -1,0 +1,31 @@
+# WPPedia User Documentation
+
+This section is for editors, content managers, and site owners using WPPedia day-to-day.
+
+## Start here
+
+1. [Install and activate](./getting-started/install-and-activate.md)
+2. [First glossary entry](./content/create-glossary-entries.md)
+3. [Settings overview](./settings/overview.md)
+
+## User guides by area
+
+### Getting started
+- [Install and activate](./getting-started/install-and-activate.md)
+- [Initial setup checklist](./getting-started/initial-setup-checklist.md)
+
+### Content management
+- [Create glossary entries](./content/create-glossary-entries.md)
+- [Editorial workflow and quality](./content/editorial-best-practices.md)
+
+### Configuration
+- [Settings overview](./settings/overview.md)
+- [Permalinks and URL behavior](./settings/permalinks.md)
+- [Search, navigation, and display options](./settings/display-and-search.md)
+
+### Frontend behavior
+- [Glossary archive and single pages](./frontend/archive-and-single-pages.md)
+- [Tooltips and cross-linking](./frontend/tooltips-and-crosslinking.md)
+
+### Troubleshooting
+- [Common issues and fixes](./troubleshooting/common-issues.md)

--- a/docs/users/settings/display-and-search.md
+++ b/docs/users/settings/display-and-search.md
@@ -1,0 +1,39 @@
+# Search, Navigation, and Display Options
+
+## 1) Search visibility
+
+Enable glossary search where your users actually need it:
+
+- archive page,
+- single entry pages (if contextual lookup is useful).
+
+## 2) Character navigation
+
+Initial-letter navigation is useful for larger glossaries and dictionary-style usage.
+
+When to enable:
+
+- many entries,
+- users browse alphabetically.
+
+When to disable:
+
+- small curated glossary,
+- topic-based discovery is primary.
+
+## 3) Archive vs single display tuning
+
+Typical tuning options include:
+
+- excerpt length,
+- image/title emphasis,
+- component visibility.
+
+> Screenshot placeholder: Archive display settings.
+> Screenshot placeholder: Single page display settings.
+
+## 4) Optimization tips
+
+- Reduce visual clutter for first-time users.
+- Keep search/navigational tools consistent across archive/single where possible.
+- Validate settings on mobile and tablet layouts.

--- a/docs/users/settings/overview.md
+++ b/docs/users/settings/overview.md
@@ -1,0 +1,25 @@
+# Settings Overview
+
+WPPedia settings control structure, discoverability, and reading experience.
+
+## 1) Main categories to review
+
+- **Permalinks / base slug** – controls glossary URL structure.
+- **Archive display** – controls list behavior and visibility of components.
+- **Single display** – controls details on individual term pages.
+- **Search/navigation visibility** – controls discovery features.
+- **Tooltip/cross-link options** – controls inline assistance behavior.
+
+> Screenshot placeholder: Settings page with each section annotated.
+
+## 2) Suggested setup order
+
+1. Set permalinks first.
+2. Configure archive and single display toggles.
+3. Configure navigation/search visibility.
+4. Configure tooltips/cross-links.
+5. Save and run a quick frontend validation.
+
+## 3) Change management tip
+
+For production sites, apply one settings category at a time and test between changes to isolate issues quickly.

--- a/docs/users/settings/permalinks.md
+++ b/docs/users/settings/permalinks.md
@@ -1,0 +1,26 @@
+# Permalinks and URL Behavior
+
+## 1) Why this matters
+
+Permalink settings determine:
+
+- glossary archive URL,
+- single term URL structure,
+- long-term SEO link stability.
+
+## 2) After changing permalink-related settings
+
+Always flush rewrite rules:
+
+1. Go to **Settings → Permalinks**.
+2. Click **Save Changes** (without needing additional edits).
+
+This forces WordPress to refresh routing rules.
+
+## 3) Best practices
+
+- Choose stable slug conventions early.
+- Avoid frequent slug/base changes.
+- If URLs change, configure redirects where needed.
+
+> Screenshot placeholder: Permalinks screen save action.

--- a/docs/users/troubleshooting/common-issues.md
+++ b/docs/users/troubleshooting/common-issues.md
@@ -1,0 +1,44 @@
+# Common Issues and Fixes
+
+## 1) Glossary menu missing in admin
+
+Check:
+
+- plugin is active,
+- user role has sufficient permissions,
+- no fatal plugin conflict is hiding menu registration.
+
+## 2) Glossary entries not visible on frontend
+
+Check:
+
+- entries are **Published**,
+- permalink settings are flushed,
+- theme templates are not overriding output incorrectly,
+- cache layers are cleared.
+
+## 3) Search form or navigation not visible
+
+Check:
+
+- corresponding display toggles are enabled,
+- page context supports component display,
+- custom theme CSS is not hiding the element.
+
+## 4) Tooltips/cross-links not appearing
+
+Check:
+
+- related options enabled,
+- content includes matching target terms,
+- JS/CSS assets load correctly,
+- cache/CDN invalidation completed.
+
+## 5) Fast isolation workflow
+
+1. Switch temporarily to a default WordPress theme.
+2. Disable non-essential plugins.
+3. Re-test glossary flow.
+4. Re-enable components one by one until issue reappears.
+
+This usually identifies whether issue source is settings, theme, or plugin conflict.


### PR DESCRIPTION
### Motivation
- Split the previous monolithic developer and user guides into a hierarchical set of focused pages to make extension points and user workflows easier to find and maintain.  
- Prioritise developer-facing guidance around extending WPPedia (hooks, templating, companion plugins) and provide detailed pages for contribution and testing so extension authors have clear processes.  
- Break user guidance into separate pages per functionality (install, creating entries, settings, frontend behavior, troubleshooting) and add screenshot placeholders for key UI touchpoints to aid editors and site owners.

### Description
- Removed the aggregate files and added a top-level index `docs/readme.md` that routes readers into the new hierarchies under `docs/developers/` and `docs/users/`.  
- Introduced developer-focused pages under `docs/developers/` including `architecture/overview.md`, `extending/` (overview, `hooks.md`, `shortcodes-and-frontend.md`), `templating/` (overview, `overrides.md`, `hooks.md`), `testing/readme.md`, and `contributing/readme.md`.  
- Introduced user-focused pages under `docs/users/` with `getting-started/`, `content/`, `settings/`, `frontend/`, and `troubleshooting/` subfolders, splitting each functionality into its own document and including screenshot placeholders.  
- Kept all changes confined to documentation, preserved intra-doc link structure, and updated the developer and user readmes to present the new structure and entry points.

### Testing
- Ran a custom markdown link validation script across `docs/` (via a small `python` script) which returned `OK`.  
- Verified that only documentation files were modified and no runtime/plugin code was changed.  
- No additional PHPUnit or runtime tests were required because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d938a7b548326b31eee56b4e4d676)